### PR TITLE
Make it work, add ability to mark current state

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ And then execute:
 
     $ bundle
 
-## Usage
+## Using the rake task
 
 To generate a state machine visualization for your `Model`, run
 
@@ -47,14 +47,38 @@ of the state machine as second parameter
 rake 'stateoscope:visualize[Model,specific_state_machine]'
 ```
 
-In both cases, a PDF file containing the graph visualization will be saved to
+If you want to highlight a specific state of your state machine, add the name as a third argument.
+
+```ruby
+rake 'stateoscope:visualize[Order,order_state,delivered]'
+```
+
+In any case, a PDF file containing the graph visualization will be saved to
 the current directory.
+
+## Using Stateoscope directly
+
+Stateoscope exposes a `visualize` method that allows for a more fine-grained and dynamic usage.
+
+Example:
+
+```ruby
+filename = Stateoscope.visualize(
+  Order,
+  state_machine_name: "order_state",
+  current_state: "delivered",
+  dir: Rails.root.join("public"), # default current directory
+  format: "png" # default "pdf", possible are all formats that GraphViz supports
+)
+
+# filename will be for example RAILS_ROOT/public/order_state-20191201145422.png
+```
 
 ## Adapters
 
 Stateoscope ships with adapters for the following state machine gems:
 
-* [AASM](https://github.com/aasm/aasm)
+- [AASM](https://github.com/aasm/aasm)
 
 ## Development
 
@@ -65,4 +89,3 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/padde/stateoscope.
-

--- a/lib/stateoscope.rb
+++ b/lib/stateoscope.rb
@@ -12,12 +12,15 @@ require 'stateoscope/railtie' if defined?(Rails)
 module Stateoscope
   def self.visualize(klass, options = {})
     state_machine_name = options.fetch(:state_machine_name, nil)
+    dir = options[:dir]
+    format = options.fetch(:format, 'pdf')
     adapter = Adapter.new_for(klass, state_machine_name)
     adapter.build_graph
     filename = filename_for(adapter)
     visualizer = Visualizer.new(adapter.graph, options[:current_state])
     visualizer.parse_graph
-    visualizer.output(filename)
+    filename = File.join(dir, filename) if dir.present?
+    visualizer.output(filename, format)
   end
 
   def self.filename_for(adapter)

--- a/lib/stateoscope.rb
+++ b/lib/stateoscope.rb
@@ -15,7 +15,7 @@ module Stateoscope
     adapter = Adapter.new_for(klass, state_machine_name)
     adapter.build_graph
     filename = filename_for(adapter)
-    visualizer = Visualizer.new(adapter.graph)
+    visualizer = Visualizer.new(adapter.graph, options[:current_state])
     visualizer.parse_graph
     visualizer.output(filename)
   end

--- a/lib/stateoscope.rb
+++ b/lib/stateoscope.rb
@@ -11,7 +11,7 @@ require 'stateoscope/railtie' if defined?(Rails)
 
 module Stateoscope
   def self.visualize(klass, options = {})
-    state_machine_name = options.fetch(:state_machine_name, nil)
+    state_machine_name = options[:state_machine_name]
     dir = options[:dir]
     format = options.fetch(:format, 'pdf')
     adapter = Adapter.new_for(klass, state_machine_name)

--- a/lib/stateoscope.rb
+++ b/lib/stateoscope.rb
@@ -11,19 +11,21 @@ require 'stateoscope/railtie' if defined?(Rails)
 
 module Stateoscope
   def self.visualize(klass, options = {})
-    state_machine_name = options[:state_machine_name]
-    dir = options[:dir]
-    format = options.fetch(:format, 'pdf')
-    adapter = Adapter.new_for(klass, state_machine_name)
+    adapter = Adapter.new_for(klass, options[:state_machine_name])
     adapter.build_graph
-    filename = filename_for(adapter)
-    visualizer = Visualizer.new(adapter.graph, options[:current_state])
-    visualizer.parse_graph
-    filename = File.join(dir, filename) if dir.present?
-    visualizer.output(filename, format)
+
+    visualizer = Visualizer.new(adapter.graph)
+    visualizer.parse_graph(options[:current_state])
+
+    output_format = options.fetch(:format, 'pdf')
+    filename = filename_for(adapter, output_format)
+    filename = File.join(options[:dir], filename) if options[:dir].present?
+
+    visualizer.output(filename, output_format)
+    filename
   end
 
-  def self.filename_for(adapter)
-    "#{adapter.full_state_machine_name}-#{Time.now.utc.strftime('%Y%m%d%H%M%S')}"
+  def self.filename_for(adapter, output_format)
+    "#{adapter.full_state_machine_name}-#{Time.now.utc.strftime('%Y%m%d%H%M%S')}.#{output_format}"
   end
 end

--- a/lib/stateoscope/adapter/base.rb
+++ b/lib/stateoscope/adapter/base.rb
@@ -2,12 +2,15 @@ require 'stateoscope/graph'
 
 module Stateoscope
   module Adapter
-    Base = Struct.new(:klass, :state_machine_name, :graph) do
+    class Base
+      attr_accessor :klass, :state_machine_name, :graph
       def self.handle?(_klass, _state_machine_name)
         fail AbstractMethodError
       end
 
-      def initialize
+      def initialize(klass, state_machine_name)
+        self.klass = klass
+        self.state_machine_name = state_machine_name
         self.graph = Graph.new
       end
 

--- a/lib/stateoscope/visualizer.rb
+++ b/lib/stateoscope/visualizer.rb
@@ -1,20 +1,17 @@
 require 'ruby-graphviz'
 
 module Stateoscope
-  Visualizer = Struct.new(:graph, :current_state) do
-    def parse_graph
+  Visualizer = Struct.new(:graph) do
+    def parse_graph(current_state)
       @viz = GraphViz.new(:G, type: 'digraph')
       add_entry_point
-      add_states
+      add_states(current_state)
       add_entry_point_transition
       add_state_transitions
     end
 
-    def output(filename, format)
-      options = {}
-      options[format] = "#{filename}.#{format}"
-      @viz.output(options)
-      "#{filename}.#{format}"
+    def output(filename, output_format)
+      @viz.output(output_format => filename)
     end
 
     private
@@ -26,7 +23,7 @@ module Stateoscope
       add_node(ENTRY_POINT, shape: 'circle', label: '', style: 'filled', color: 'black', fixedsize: true, width: 0.3)
     end
 
-    def add_states
+    def add_states(current_state)
       graph.states.each do |state|
         options = { peripheries: graph.final_state?(state) ? 2 : 1 }
         options[:color] = 'green' if state == current_state

--- a/lib/stateoscope/visualizer.rb
+++ b/lib/stateoscope/visualizer.rb
@@ -1,7 +1,7 @@
 require 'ruby-graphviz'
 
 module Stateoscope
-  Visualizer = Struct.new(:graph) do
+  Visualizer = Struct.new(:graph, :current_state) do
     def parse_graph
       @viz = GraphViz.new(:G, type: 'digraph')
       add_entry_point
@@ -25,7 +25,9 @@ module Stateoscope
 
     def add_states
       graph.states.each do |state|
-        add_node(state, peripheries: graph.final_state?(state) ? 2 : 1)
+        options = { peripheries: graph.final_state?(state) ? 2 : 1 }
+        options[:color] = 'green' if state == current_state
+        add_node(state, options)
       end
     end
 

--- a/lib/stateoscope/visualizer.rb
+++ b/lib/stateoscope/visualizer.rb
@@ -10,8 +10,11 @@ module Stateoscope
       add_state_transitions
     end
 
-    def output(filename)
-      @viz.output(pdf: "#{filename}.pdf")
+    def output(filename, format)
+      options = {}
+      options[format] = "#{filename}.#{format}"
+      @viz.output(options)
+      "#{filename}.#{format}"
     end
 
     private

--- a/lib/tasks/stateoscope.rake
+++ b/lib/tasks/stateoscope.rake
@@ -1,10 +1,9 @@
 namespace :stateoscope do
   desc 'visualize state machine for a given class'
   task :visualize, %i[class state_machine_name current_state] => :environment do |_, args|
-    raise ArgumentError, 'missing required argument <class>' if args[:class].nil?
-    klass = args[:class].classify.constantize
-    # class not needed in args
-    args = args.reject { |k, _| k == :class }.to_h
-    Stateoscope.visualize(klass, args)
+    args = args.to_hash
+    klass = args.delete(:class)
+    raise ArgumentError, 'missing required argument <class>' if klass.blank?
+    Stateoscope.visualize(klass.classify.constantize, args)
   end
 end

--- a/lib/tasks/stateoscope.rake
+++ b/lib/tasks/stateoscope.rake
@@ -3,6 +3,8 @@ namespace :stateoscope do
   task :visualize, %i[class state_machine_name current_state] => :environment do |_, args|
     raise ArgumentError, 'missing required argument <class>' if args[:class].nil?
     klass = args[:class].classify.constantize
+    # class not needed in args
+    args = args.reject { |k, _| k == :class }.to_h
     Stateoscope.visualize(klass, args)
   end
 end

--- a/lib/tasks/stateoscope.rake
+++ b/lib/tasks/stateoscope.rake
@@ -1,8 +1,8 @@
 namespace :stateoscope do
   desc 'visualize state machine for a given class'
-  task :visualize, [:class, :state_machine_name] => :environment do |t, args|
+  task :visualize, [:class, :state_machine_name, :current_state] => :environment do |t, args|
     fail ArgumentError, 'missing required argument <class>' unless args[:class].present?
     klass = args[:class].classify.constantize
-    Stateoscope.visualize(klass, state_machine_name: args[:state_machine_name])
+    Stateoscope.visualize(klass, state_machine_name: args[:state_machine_name], current_state: args[:current_state])
   end
 end

--- a/lib/tasks/stateoscope.rake
+++ b/lib/tasks/stateoscope.rake
@@ -1,8 +1,8 @@
 namespace :stateoscope do
   desc 'visualize state machine for a given class'
-  task :visualize, [:class, :state_machine_name, :current_state] => :environment do |t, args|
-    fail ArgumentError, 'missing required argument <class>' unless args[:class].present?
+  task :visualize, %i[class state_machine_name current_state] => :environment do |_, args|
+    raise ArgumentError, 'missing required argument <class>' if args[:class].nil?
     klass = args[:class].classify.constantize
-    Stateoscope.visualize(klass, state_machine_name: args[:state_machine_name], current_state: args[:current_state])
+    Stateoscope.visualize(klass, args)
   end
 end

--- a/spec/lib/stateoscope/adapter/base_spec.rb
+++ b/spec/lib/stateoscope/adapter/base_spec.rb
@@ -6,19 +6,22 @@ RSpec.describe Stateoscope::Adapter::Base do
     it { is_expected.to have_abstract_method(:handle?) }
   end
 
+  class Dummy; end
+
   describe '#initialize' do
     it 'initializes a graph' do
-      class Example; end
-      adapter = described_class.new Example, "ExampleState"
+      adapter = described_class.new Dummy, "DummyState"
       expect(adapter.graph).to be_a(Stateoscope::Graph)
     end
   end
 
   describe '#build_graph' do
+    subject { described_class.new(Dummy, "State") }
     it { is_expected.to have_abstract_method(:build_graph) }
   end
 
   describe '#full_state_machine_name' do
+    subject { described_class.new(Dummy, "OK") }
     it { is_expected.to have_abstract_method(:full_state_machine_name) }
   end
 end

--- a/spec/lib/stateoscope/adapter/base_spec.rb
+++ b/spec/lib/stateoscope/adapter/base_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Stateoscope::Adapter::Base do
 
   describe '#initialize' do
     it 'initializes a graph' do
-      adapter = described_class.new
+      class Example; end
+      adapter = described_class.new Example, "ExampleState"
       expect(adapter.graph).to be_a(Stateoscope::Graph)
     end
   end

--- a/spec/lib/stateoscope/tasks/stateoscope_rake_spec.rb
+++ b/spec/lib/stateoscope/tasks/stateoscope_rake_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'rake stateoscope' do
         stateoscope = class_double('Stateoscope').as_stubbed_const
         allow(stateoscope).to receive(:visualize)
         rake['stateoscope:visualize'].invoke('DummyClass')
-        expect(stateoscope).to have_received(:visualize).with(DummyClass, state_machine_name: nil)
+        expect(stateoscope).to have_received(:visualize).with(DummyClass, {})
       end
     end
 
@@ -39,6 +39,15 @@ RSpec.describe 'rake stateoscope' do
         allow(stateoscope).to receive(:visualize)
         rake['stateoscope:visualize'].invoke('DummyClass', 'foo')
         expect(stateoscope).to have_received(:visualize).with(DummyClass, state_machine_name: 'foo')
+      end
+    end
+
+    context 'with three arguments' do
+      it 'invokes Stateoscope.visualize with the supplied class and state_machine_name and current_state' do
+        stateoscope = class_double('Stateoscope').as_stubbed_const
+        allow(stateoscope).to receive(:visualize)
+        rake['stateoscope:visualize'].invoke('DummyClass', 'foo', 'bar')
+        expect(stateoscope).to have_received(:visualize).with(DummyClass, state_machine_name: 'foo', current_state: 'bar')
       end
     end
   end

--- a/spec/lib/stateoscope_spec.rb
+++ b/spec/lib/stateoscope_spec.rb
@@ -20,8 +20,8 @@ describe Stateoscope do
         expect(described_class).to receive(:filename_for).with(adapter).and_return('filename')
 
         visualizer = double(Stateoscope::Visualizer, parse_graph: nil)
-        expect(Stateoscope::Visualizer).to receive(:new).with(graph).and_return(visualizer)
-        expect(visualizer).to receive(:output).with('filename')
+        expect(Stateoscope::Visualizer).to receive(:new).with(graph, nil).and_return(visualizer)
+        expect(visualizer).to receive(:output).with('filename', 'pdf')
 
         described_class.visualize(DummyClass)
       end
@@ -37,8 +37,8 @@ describe Stateoscope do
         expect(described_class).to receive(:filename_for).with(adapter).and_return('filename')
 
         visualizer = double(Stateoscope::Visualizer, parse_graph: nil)
-        expect(Stateoscope::Visualizer).to receive(:new).with(graph).and_return(visualizer)
-        expect(visualizer).to receive(:output).with('filename')
+        expect(Stateoscope::Visualizer).to receive(:new).with(graph, nil).and_return(visualizer)
+        expect(visualizer).to receive(:output).with('filename', 'pdf')
 
         described_class.visualize(DummyClass, state_machine_name: :foobar)
       end
@@ -48,7 +48,7 @@ describe Stateoscope do
   describe '.filename_for' do
     it 'generates a filename with the state machine name and utc timestamp' do
       adapter = object_double(
-        Stateoscope::Adapter::Base.new,
+        Stateoscope::Adapter::Base.new(DummyClass, 'Example'),
         full_state_machine_name: 'foo'
       )
       Timecop.freeze(Time.new(2015, 1, 2, 3, 4, 5, 0)) do

--- a/spec/lib/stateoscope_spec.rb
+++ b/spec/lib/stateoscope_spec.rb
@@ -17,10 +17,10 @@ describe Stateoscope do
         adapter = double(Stateoscope::Adapter::Base, build_graph: nil, graph: graph)
         expect(Stateoscope::Adapter).to receive(:new_for).with(DummyClass, nil).and_return(adapter)
 
-        expect(described_class).to receive(:filename_for).with(adapter).and_return('filename')
+        expect(described_class).to receive(:filename_for).with(adapter, 'pdf').and_return('filename')
 
         visualizer = double(Stateoscope::Visualizer, parse_graph: nil)
-        expect(Stateoscope::Visualizer).to receive(:new).with(graph, nil).and_return(visualizer)
+        expect(Stateoscope::Visualizer).to receive(:new).with(graph).and_return(visualizer)
         expect(visualizer).to receive(:output).with('filename', 'pdf')
 
         described_class.visualize(DummyClass)
@@ -34,13 +34,34 @@ describe Stateoscope do
         adapter = double(Stateoscope::Adapter::Base, build_graph: nil, graph: graph)
         expect(Stateoscope::Adapter).to receive(:new_for).with(DummyClass, :foobar).and_return(adapter)
 
-        expect(described_class).to receive(:filename_for).with(adapter).and_return('filename')
+        expect(described_class).to receive(:filename_for).with(adapter, 'pdf').and_return('filename.pdf')
 
         visualizer = double(Stateoscope::Visualizer, parse_graph: nil)
-        expect(Stateoscope::Visualizer).to receive(:new).with(graph, nil).and_return(visualizer)
-        expect(visualizer).to receive(:output).with('filename', 'pdf')
+        expect(Stateoscope::Visualizer).to receive(:new).with(graph).and_return(visualizer)
+        expect(visualizer).to receive(:output).with('filename.pdf', 'pdf').and_return('filename.pdf')
+        expect(visualizer).to receive(:parse_graph).with(nil)
 
-        described_class.visualize(DummyClass, state_machine_name: :foobar)
+        expect(described_class.visualize(DummyClass, state_machine_name: :foobar)).to eq 'filename.pdf'
+      end
+    end
+
+
+    context 'with current_state, format and dir option' do
+      it 'runs a visualizer' do
+        graph = double(Stateoscope::Graph)
+
+        adapter = double(Stateoscope::Adapter::Base, build_graph: nil, graph: graph)
+        expect(Stateoscope::Adapter).to receive(:new_for).with(DummyClass, nil).and_return(adapter)
+
+        expect(described_class).to receive(:filename_for).with(adapter, 'png').and_return('filename.png')
+
+        visualizer = double(Stateoscope::Visualizer, parse_graph: nil)
+        expect(Stateoscope::Visualizer).to receive(:new).with(graph).and_return(visualizer)
+        expect(visualizer).to receive(:output).with('/var/www/app/public/filename.png', 'png').and_return('filename.png')
+        expect(visualizer).to receive(:parse_graph).with('delivered')
+
+        result = described_class.visualize(DummyClass, dir: '/var/www/app/public', current_state: 'delivered', format: 'png')
+        expect(result).to eq '/var/www/app/public/filename.png'
       end
     end
   end
@@ -52,7 +73,7 @@ describe Stateoscope do
         full_state_machine_name: 'foo'
       )
       Timecop.freeze(Time.new(2015, 1, 2, 3, 4, 5, 0)) do
-        expect(described_class.filename_for(adapter)).to eq('foo-20150102030405')
+        expect(described_class.filename_for(adapter, 'pdf')).to eq('foo-20150102030405.pdf')
       end
     end
   end


### PR DESCRIPTION
Hello, I believe this actually didn't work anymore. I kept getting `ArgumentError` for `Stateoscope::Adapter::Base#initialize`.  Is it still maintained? 

I made it work again and added some sugar. You can now configure the output format via `options` and also pass a `current_state` which node will be coloured green. I believe this can be very helpful.